### PR TITLE
tests for ggplot.ts

### DIFF
--- a/R/try-data-frame.R
+++ b/R/try-data-frame.R
@@ -85,7 +85,7 @@ try_data_frame <- function(x,
     if (lubridate::is.POSIXct(times.raw) || lubridate::is.Date(times.raw)) {
       times <- times.raw
     } else if (inherits(times.raw, "yearmon")) {
-      times <- as.POSIXct(format(times.raw, "%Y-%m-01"))
+      times <- as.POSIXct(format(times.raw, "%Y-%m-01"),  tz = "UTC", format = "%Y-%m-%d")
     } else if (inherits(times.raw, "yearqtr")) {
       times <- zoo::as.Date(times.raw)
     } else if (is.numeric(times.raw)) {

--- a/tests/testthat/test-ggplot_ts.R
+++ b/tests/testthat/test-ggplot_ts.R
@@ -1,0 +1,66 @@
+context("ggplot.ts")
+
+test_that("ggplot.ts works as expected with the yearly time series.", {
+  data <- lynx
+
+  expect_silent(p <- ggplot.ts(data) + geom_line())
+  res <- layer_data(p)
+
+  expect_equal(res$x, as.numeric(time(data)))
+  expect_equal(res$y, as.numeric(data))
+})
+
+test_that("ggplot.ts works as expected with the monthly time series.", {
+  data <- sunspots
+
+  expect_silent(p <- ggplot.ts(data) + geom_line())
+  res <- layer_data(p)
+
+  expect_equal(res$x, as.numeric(time(data)))
+  expect_equal(res$y, as.numeric(data))
+})
+
+test_that("ggplot.ts time resolution works as expected.", {
+  data <- sunspot.month
+  expected <- zoo::as.Date(time(data))
+  expected <- lubridate::round_date(expected, unit = "year")
+  expected_pos <- as.numeric(as.POSIXct(expected))
+
+  expect_silent(
+    p <- ggplot.ts(data, as.numeric = FALSE, time.resolution = "year") +
+      geom_point()
+  )
+  res <- layer_data(p, 1)
+
+  expect_equal(res$x, expected_pos)
+  expect_equal(res$y, as.numeric(data))
+})
+
+test_that("ggplot.ts mapping works as expected.", {
+  data <- sunspot.month
+
+  data <- sunspot.month
+  expected <- zoo::as.Date(time(data))
+  expected <- lubridate::round_date(expected, unit = "10 year")
+
+  expected_med <- as.numeric(tapply(as.numeric(data), expected, median))
+  expected_q1 <- as.numeric(tapply(as.numeric(data), expected, quantile, probs = 0.25))
+  expected_q3 <- as.numeric(tapply(as.numeric(data), expected, quantile, probs = 0.75))
+
+  expect_silent(
+    p <- ggplot.ts(
+      data,
+      mapping = aes(x = data, y = time, group = time),
+      as.numeric = FALSE,
+      time.resolution = "10 year"
+    ) +
+      geom_boxplot()
+  )
+
+  res <- layer_data(p)
+
+  expect_equal(res$y, unique(as.numeric(as.POSIXct(expected))))
+  expect_equal(res$xmiddle, expected_med)
+  expect_equal(res$xlower, expected_q1)
+  expect_equal(res$xupper, expected_q3)
+})


### PR DESCRIPTION
this PR contains test for the `ggplot.ts` method.

I noticed a little unexpected behaviour: 

```
 try_data_frame(sunspots)
 Error in as.POSIXlt.character(x, tz, ...) : 
character string is not in a standard unambiguous format
```

I suggested a small modification to circumvent it. Please correct me if this is susceptible to cause problems later on.

thank you for your review and suggestions