### PR TITLE
Disable gh-pages publishing of coverage report

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -20,3 +20,5 @@ jobs:
     uses: insightsengineering/r.pkg.template/.github/workflows/test-coverage.yaml@main
     secrets:
       REPO_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    with:
+      publish-coverage-report-gh-pages: false


### PR DESCRIPTION
Because currently `ggpp` does not have a gh-pages branch to host the `pkgdown` website.